### PR TITLE
refactor: max methods now take a caller

### DIFF
--- a/contracts/ERC4626.json
+++ b/contracts/ERC4626.json
@@ -41,7 +41,10 @@
   "name": "maxDeposit",
   "type": "function",
   "stateMutability": "view",
-  "inputs": [],
+  "inputs": [{
+    "name": "caller",
+    "type": "address"
+  }],
   "outputs": [{
     "name": "maxAssets",
     "type": "uint256"
@@ -77,7 +80,10 @@
   "name": "maxMint",
   "type": "function",
   "stateMutability": "view",
-  "inputs": [],
+  "inputs": [{
+    "name": "caller",
+    "type": "address"
+  }],
   "outputs": [{
     "name": "maxShares",
     "type": "uint256"
@@ -113,7 +119,10 @@
   "name": "maxWithdraw",
   "type": "function",
   "stateMutability": "view",
-  "inputs": [],
+  "inputs": [{
+    "name": "caller",
+    "type": "address"
+  }],
   "outputs": [{
     "name": "maxAssets",
     "type": "uint256"
@@ -152,7 +161,10 @@
   "name": "maxRedeem",
   "type": "function",
   "stateMutability": "view",
-  "inputs": [],
+  "inputs": [{
+    "name": "caller",
+    "type": "address"
+  }],
   "outputs": [{
     "name": "maxShares",
     "type": "uint256"

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -140,7 +140,7 @@ def _calculateShares(assetAmount: uint256) -> uint256:
 
 @view
 @external
-def maxDeposit() -> uint256:
+def maxDeposit(owner: address) -> uint256:
     return MAX_UINT256
 
 
@@ -163,7 +163,7 @@ def deposit(assets: uint256, receiver: address=msg.sender) -> uint256:
 
 @view
 @external
-def maxMint() -> uint256:
+def maxMint(owner: address) -> uint256:
     return MAX_UINT256
 
 
@@ -196,7 +196,7 @@ def mint(shares: uint256, receiver: address=msg.sender) -> uint256:
 
 @view
 @external
-def maxWithdraw() -> uint256:
+def maxWithdraw(owner: address) -> uint256:
     return MAX_UINT256  # real max is `self.asset.balanceOf(self)`
 
 
@@ -233,7 +233,7 @@ def withdraw(assets: uint256, receiver: address=msg.sender, sender: address=msg.
 
 @view
 @external
-def maxRedeem() -> uint256:
+def maxRedeem(owner: address) -> uint256:
     return MAX_UINT256  # real max is `self.totalSupply`
 
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -5,11 +5,13 @@ def test_asset(vault, token):
     assert vault.asset() == token
 
 
-def test_max_methods(vault):
-    assert vault.maxDeposit() == 2**256 - 1
-    assert vault.maxMint() == 2**256 - 1
-    assert vault.maxWithdraw() == 2**256 - 1
-    assert vault.maxRedeem() == 2**256 - 1
+def test_max_methods(accounts, vault):
+    a = accounts[0]
+
+    assert vault.maxDeposit(a) == 2**256 - 1
+    assert vault.maxMint(a) == 2**256 - 1
+    assert vault.maxWithdraw(a) == 2**256 - 1
+    assert vault.maxRedeem(a) == 2**256 - 1
 
 
 def test_preview_methods(accounts, token, vault):


### PR DESCRIPTION
Requires `ethpm-types` b6 release