### PR TITLE
fix: redeem & withdraw

### DIFF
--- a/contracts/SolidityVault.sol
+++ b/contracts/SolidityVault.sol
@@ -96,7 +96,9 @@ contract SolidityVault is IERC4626, ERC20 {
     {
         uint256 shares = convertToShares(assets);
 
-        _spendAllowance(owner, msg.sender, shares);
+        if (owner != msg.sender) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
         _burn(owner, shares);
 
         ERC20(asset).transfer(receiver, assets);
@@ -131,7 +133,9 @@ contract SolidityVault is IERC4626, ERC20 {
     {
         uint256 assets = convertToAssets(shares);
 
-        _spendAllowance(owner, msg.sender, shares);
+        if (owner != msg.sender) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
         _burn(owner, shares);
 
         ERC20(asset).transfer(receiver, assets);


### PR DESCRIPTION
According to [EIP-4626](https://eips.ethereum.org/EIPS/eip-4626),

> `redeem` MUST support a redeem flow where the shares are burned from owner directly where owner is msg.sender.
> `wothdraw` MUST support a redeem flow where the shares are burned from owner directly where owner is msg.sender.

It is weird that user must approve himself to redeem/withdraw, when `owner` and `msg.sender` is the same.