### PR TITLE
feat: add missing transfer events

### DIFF
--- a/contracts/SolidityVault.sol
+++ b/contracts/SolidityVault.sol
@@ -41,6 +41,7 @@ contract SolidityVault is IERC4626, ERC20 {
 
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit Transfer(address(0), receiver, shares);
 
         return shares;
     }
@@ -68,6 +69,7 @@ contract SolidityVault is IERC4626, ERC20 {
 
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit Transfer(address(0), receiver, shares);
 
         return assets;
     }
@@ -103,6 +105,7 @@ contract SolidityVault is IERC4626, ERC20 {
 
         ERC20(asset).transfer(receiver, assets);
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        emit Transfer(owner, address(0), shares);
 
         return shares;
     }
@@ -140,6 +143,7 @@ contract SolidityVault is IERC4626, ERC20 {
 
         ERC20(asset).transfer(receiver, assets);
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        emit Transfer(owner, address(0), shares);
 
         return assets;
     }

--- a/contracts/VyperVault.vy
+++ b/contracts/VyperVault.vy
@@ -153,6 +153,7 @@ def deposit(assets: uint256, receiver: address=msg.sender) -> uint256:
     self.totalSupply += shares
     self.balanceOf[receiver] += shares
     log Deposit(msg.sender, receiver, assets, shares)
+    log Transfer(empty(address), receiver, shares)
     return shares
 
 
@@ -186,6 +187,7 @@ def mint(shares: uint256, receiver: address=msg.sender) -> uint256:
     self.totalSupply += shares
     self.balanceOf[receiver] += shares
     log Deposit(msg.sender, receiver, assets, shares)
+    log Transfer(empty(address), receiver, shares)
     return assets
 
 
@@ -223,6 +225,7 @@ def withdraw(assets: uint256, receiver: address=msg.sender, owner: address=msg.s
 
     self.asset.transfer(receiver, assets)
     log Withdraw(msg.sender, receiver, owner, assets, shares)
+    log Transfer(owner, empty(address), shares)
     return shares
 
 
@@ -249,6 +252,7 @@ def redeem(shares: uint256, receiver: address=msg.sender, owner: address=msg.sen
 
     self.asset.transfer(receiver, assets)
     log Withdraw(msg.sender, receiver, owner, assets, shares)
+    log Transfer(owner, empty(address), shares)
     return assets
 
 


### PR DESCRIPTION
i've seen a live implementation ([sDAI](https://etherscan.deth.net/address/0x83F20F44975D03b1b09e64809B757c47f942BEeA)) that doesn't emit a `Transfer` event on `mint/deposit/burn/withdraw`, which breaks token detection for both explorers and wallets.

i noticed that the examples miss this too, so i added the missing events, which are both a recommended part of [eip-20](https://eips.ethereum.org/EIPS/eip-20) and a widely accepted convention.

> A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created.